### PR TITLE
feat: Steam补丁ID重新刮削——单个补丁+批量刮削按钮

### DIFF
--- a/client/lib/screens/steam_patch_screen.dart
+++ b/client/lib/screens/steam_patch_screen.dart
@@ -32,6 +32,7 @@ class _SteamPatchScreenState extends State<SteamPatchScreen> {
   // Server tab
   List<Map<String, dynamic>> _serverPatches = [];
   bool _serverLoading = false;
+  bool _rescraping = false;
   String? _serverStatus;
 
   @override
@@ -126,6 +127,43 @@ class _SteamPatchScreenState extends State<SteamPatchScreen> {
       if (!mounted) return;
       setState(() { _serverLoading = false; _serverStatus = "扫描失败: $e"; });
     }
+  }
+
+  Future<void> _rescrapeOne(String lookupKey) async {
+    final api = context.read<GameProvider>().api;
+    setState(() => _serverStatus = "正在刮削 $lookupKey ...");
+    try {
+      final result = await SteamService.rescrapePatch(api, lookupKey);
+      if (!mounted) return;
+      final status = result["status"] ?? "";
+      if (status == "updated") {
+        _showMsg("刮削成功\n新 AppID: ${result["new_app_id"]}${result["game_name"] != null && result["game_name"] != "" ? "\n游戏名: ${result["game_name"]}" : ""}");
+        _loadServerPatches();
+      } else if (status == "skipped") {
+        _showMsg("已有 AppID，跳过刮削");
+      } else {
+        _showMsg("刮削失败: 未找到匹配的 Steam 游戏");
+      }
+    } catch (e) {
+      if (mounted) _showMsg("刮削失败: $e", error: true);
+    }
+    if (mounted) setState(() => _serverStatus = null);
+  }
+
+  Future<void> _rescrapeAll() async {
+    final api = context.read<GameProvider>().api;
+    setState(() { _rescraping = true; _serverStatus = "正在批量刮削 AppID ..."; });
+    try {
+      final result = await SteamService.rescrapeAllPatches(api);
+      if (!mounted) return;
+      final updated = result["updated"] ?? 0;
+      final total = result["total"] ?? 0;
+      _showMsg("批量刮削完成: $updated / $total 个更新");
+      _loadServerPatches();
+    } catch (e) {
+      if (mounted) _showMsg("批量刮削失败: $e", error: true);
+    }
+    if (mounted) setState(() { _rescraping = false; _serverStatus = null; });
   }
 
   void _showMsg(String msg, {bool error = false}) {
@@ -443,6 +481,8 @@ class _SteamPatchScreenState extends State<SteamPatchScreen> {
           _miniBtn(Icons.refresh, "加载", _serverLoading ? null : _loadServerPatches),
           const SizedBox(width: 8),
           _miniBtn(Icons.folder, "扫描补丁", _serverLoading ? null : _scanServerPatches),
+          const SizedBox(width: 8),
+          _miniBtn(Icons.search, "批量刮削ID", _serverLoading || _rescraping ? null : _rescrapeAll),
         ])),
       if (_serverStatus != null) Padding(padding: const EdgeInsets.fromLTRB(20, 12, 20, 0), child: _buildServerStatusBar()),
       const SizedBox(height: 8),
@@ -501,7 +541,9 @@ class _SteamPatchScreenState extends State<SteamPatchScreen> {
                 Expanded(child: Text("$patchDir → /$targetDir", style: AppText.caption.copyWith(color: hintColor(context)))),
               ])),
           ])),
-          const SizedBox(width: 4),
+          const SizedBox(width: 2),
+          IconButton(icon: const Icon(Icons.manage_search, size: 16), tooltip: "重新刮削 AppID", visualDensity: VisualDensity.compact, padding: const EdgeInsets.all(6), constraints: const BoxConstraints(),
+            onPressed: () => _rescrapeOne(hasAppId ? appId : file)),
           IconButton(icon: const Icon(Icons.edit, size: 16), tooltip: "编辑", visualDensity: VisualDensity.compact, padding: const EdgeInsets.all(6), constraints: const BoxConstraints(),
             onPressed: () => _showEditDialog(PatchMatch(appId: appId, gameName: label.isNotEmpty ? label : file.split("/").last, installDir: "", patchAvailable: true, patchFilename: file, patchDir: patchDir, targetDir: targetDir, label: label, type: ptype))),
         ])),

--- a/client/lib/services/steam_service.dart
+++ b/client/lib/services/steam_service.dart
@@ -171,6 +171,26 @@ class SteamService {
     throw HttpException("Failed to scan patches: ${resp.statusCode}");
   }
 
+  /// Re-scrape a single patch's app_id from Steam search.
+  static Future<Map<String, dynamic>> rescrapePatch(ApiClient api, String lookupKey) async {
+    final resp = await http.post(
+      Uri.parse("${api.baseUrl}/api/steam/patches/${Uri.encodeComponent(lookupKey)}/rescrape"),
+      headers: api.headers,
+    );
+    if (resp.statusCode == 200) return jsonDecode(resp.body) as Map<String, dynamic>;
+    throw HttpException("Failed to rescrape patch: ${resp.statusCode}");
+  }
+
+  /// Batch re-scrape all patches' app_ids from Steam search.
+  static Future<Map<String, dynamic>> rescrapeAllPatches(ApiClient api) async {
+    final resp = await http.post(
+      Uri.parse("${api.baseUrl}/api/steam/patches/rescrape-all"),
+      headers: api.headers,
+    );
+    if (resp.statusCode == 200) return jsonDecode(resp.body) as Map<String, dynamic>;
+    throw HttpException("Failed to rescrape all patches: ${resp.statusCode}");
+  }
+
   /// List all indexed patches from server.
   static Future<Map<String, dynamic>> listPatches(ApiClient api) async {
     final resp = await http.get(Uri.parse("${api.baseUrl}/api/steam/patches"), headers: api.headers);

--- a/server/api/steam_patch.py
+++ b/server/api/steam_patch.py
@@ -403,6 +403,151 @@ def _find_patch_fallback(patches_dir: Path, app_id: str) -> Path | None:
     return None
 
 
+# ── Patch ID re-scrape ──
+
+class RescrapeResult(BaseModel):
+    lookup_key: str
+    file: str = ""
+    old_app_id: str = ""
+    new_app_id: str = ""
+    game_name: str = ""
+    status: str = ""  # "updated" / "skipped" / "not_found" / "error"
+
+
+@router.post("/patches/{lookup_key}/rescrape")
+async def rescrape_patch(lookup_key: str, user: User = Depends(require_admin)):
+    """Re-search Steam for a single patch's app_id and update patches.json."""
+    import asyncio as _asyncio
+    patches_dir = _get_patches_dir()
+    json_path = patches_dir / "patches.json"
+
+    if not json_path.is_file():
+        raise HTTPException(status_code=404, detail="patches.json 不存在")
+
+    try:
+        with open(json_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        raise HTTPException(status_code=400, detail="patches.json 格式错误")
+
+    patches = data.get("patches", [])
+    target = None
+    for p in patches:
+        if str(p.get("app_id", "")) == lookup_key:
+            target = p; break
+        if p.get("file", "") == lookup_key:
+            target = p; break
+
+    if target is None:
+        raise HTTPException(status_code=404, detail=f"未找到补丁: {lookup_key}")
+
+    old_app_id = str(target.get("app_id", "") or "")
+    filename = target.get("file", "").split("/")[-1]
+    from scan_patches import _extract_game_name, _search_steam_app_id, _fetch_game_name
+    game_name_candidate = _extract_game_name(filename)
+
+    try:
+        new_id = await _asyncio.to_thread(_search_steam_app_id, game_name_candidate)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Steam API 查询失败: {e}")
+
+    result = RescrapeResult(
+        lookup_key=lookup_key,
+        file=filename,
+        old_app_id=old_app_id,
+        status="not_found",
+    )
+
+    if new_id:
+        target["app_id"] = new_id
+        result.new_app_id = str(new_id)
+        result.status = "updated"
+        # Also fetch game name
+        try:
+            name = await _asyncio.to_thread(_fetch_game_name, new_id)
+            if name:
+                target["game_name"] = name
+                result.game_name = name
+        except Exception:
+            pass
+    elif old_app_id:
+        result.status = "skipped"
+        result.new_app_id = old_app_id
+
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+    return result
+
+
+@router.post("/patches/rescrape-all")
+async def rescrape_all_patches(user: User = Depends(require_admin)):
+    """Re-search Steam for all patches' app_ids (batch)."""
+    import asyncio as _asyncio
+    patches_dir = _get_patches_dir()
+    json_path = patches_dir / "patches.json"
+
+    if not json_path.is_file():
+        raise HTTPException(status_code=404, detail="patches.json 不存在")
+
+    try:
+        with open(json_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        raise HTTPException(status_code=400, detail="patches.json 格式错误")
+
+    patches = data.get("patches", [])
+    from scan_patches import _extract_game_name, _search_steam_app_id, _fetch_game_name
+
+    results: list[RescrapeResult] = []
+
+    async def rescrape_one(p: dict) -> RescrapeResult:
+        filename = p.get("file", "").split("/")[-1]
+        old_id = str(p.get("app_id", "") or "")
+        lookup = old_id or p.get("file", "")
+        game_name_candidate = _extract_game_name(filename)
+
+        r = RescrapeResult(lookup_key=lookup, file=filename, old_app_id=old_id)
+
+        if not game_name_candidate:
+            r.status = "skipped"
+            return r
+
+        try:
+            new_id = await _asyncio.to_thread(_search_steam_app_id, game_name_candidate)
+        except Exception:
+            r.status = "error"
+            return r
+
+        if new_id:
+            p["app_id"] = new_id
+            r.new_app_id = str(new_id)
+            r.status = "updated"
+            try:
+                name = await _asyncio.to_thread(_fetch_game_name, new_id)
+                if name:
+                    p["game_name"] = name
+                    r.game_name = name
+            except Exception:
+                pass
+        elif old_id:
+            r.new_app_id = old_id
+            r.status = "skipped"
+        else:
+            r.status = "not_found"
+
+        return r
+
+    tasks = [rescrape_one(p) for p in patches]
+    results = await _asyncio.gather(*tasks)
+    updated = sum(1 for r in results if r.status == "updated")
+
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+    return {"message": f"批量刮削完成: {updated} 个更新", "updated": updated, "total": len(patches), "results": [r.model_dump() for r in results]}
+
+
 # ── Steam game name resolution ──
 
 class AppIdList(BaseModel):


### PR DESCRIPTION
补丁app_id扫描错误后之前只能手动编辑patches.json修正。

服务端:
- POST /api/steam/patches/{lookup_key}/rescrape  单个重新刮削
- POST /api/steam/patches/rescrape-all           批量刮削所有补丁
- 复用scan_patches的_search_steam_app_id(同步)通过asyncio.to_thread异步化
- 批量刮削并发执行，结果汇总返回updated/total计数
- 刮削成功后自动更新game_name

客户端:
- 服务端Tab工具栏新增「批量刮削ID」按钮
- 每个补丁卡片新增放大镜按钮，无AppID用file路径、有AppID用app_id
- 刮削中禁用按钮防止重复提交