### PR TITLE
fix: 下载取消后通知未消失——cancelTask加NotificationService().cancel

### DIFF
--- a/client/lib/services/download_service.dart
+++ b/client/lib/services/download_service.dart
@@ -516,10 +516,12 @@ class DownloadService with WidgetsBindingObserver {
       task._cancelled = true;
       task.status = "cancelled";
       task.error = "已取消";
+      NotificationService().cancel(task.gameId);
       _emit();
       _cleanupTemp(task);
     } else if (task.status == "failed") {
       task.status = "cancelled";
+      NotificationService().cancel(task.gameId);
       _emit();
       _cleanupTemp(task);
     }


### PR DESCRIPTION
cancelTask取消下载任务时没有取消对应的通知栏消息，取消后
通知仍残留。加NotificationService().cancel(task.gameId)清理。

另外下载进度通知改为每秒更新一次(与速度计算同步)，进度条
在totalBytes已知时显示实际百分比，未知时显示indeterminate动画。